### PR TITLE
Check if the buffer is a TeX-mode buffer.

### DIFF
--- a/twauctex.el
+++ b/twauctex.el
@@ -363,7 +363,7 @@ If called with ARG, or already at end of line, kill the line instead."
     ;; fill column.
     (add-hook 'hack-local-variables-hook
 	      (lambda ()
-                (when twauctex-use-visual-fill-column
+          (when (and twauctex-use-visual-fill-column TeX-mode-p)
                   (visual-fill-column-mode 1))
 	      nil t))))
 ;;;###autoload


### PR DESCRIPTION
Hi,

There is an issue where adding `visual-fill-column-mode` in `hack-local-variables-hook` will also enable `visual-fill-column-mode` in every other file or modes opened after `twauctex` is enabled.
This pull request checks if the buffer is a `TeX-mode` buffer before activating the `visual-fill-column-mode`.

