### PR TITLE
Fix issue with argument passing to add-hook

### DIFF
--- a/twauctex.el
+++ b/twauctex.el
@@ -364,8 +364,8 @@ If called with ARG, or already at end of line, kill the line instead."
     (add-hook 'hack-local-variables-hook
 	      (lambda ()
                 (when twauctex-use-visual-fill-column
-                  (visual-fill-column-mode 1))
-	      nil t))))
+                  (visual-fill-column-mode 1)))
+              nil t)))
 ;;;###autoload
 (defun twauctex-enable ()
   "Enable twauctex mode."


### PR DESCRIPTION
third and forth arguments were part of the lambda, not part of the call to add-hook

This fixes the issue described in #8 without requiring an additional check.